### PR TITLE
Fix empty input schema properties breaking MCP tool discovery

### DIFF
--- a/includes/abilities/gutenberg/get-finalizer-runtime.php
+++ b/includes/abilities/gutenberg/get-finalizer-runtime.php
@@ -21,7 +21,7 @@ wp_register_ability('novamira/gutenberg-get-finalizer-runtime', [
     'input_schema' => [
         'type' => 'object',
         'default' => [],
-        'properties' => [],
+        'properties' => new \stdClass(),
         'additionalProperties' => false,
     ],
     'output_schema' => [


### PR DESCRIPTION
## Summary

Fixes #82. The `novamira/gutenberg-get-finalizer-runtime` ability declared `input_schema.properties` as a bare PHP array (`[]`). `json_encode()` serializes an empty array as a JSON array, so `tools/list` returned `inputSchema.properties: []` instead of `{}` for this ability, which fails MCP client schema validation (`expected record, received array`) and breaks discovery of the entire tool list, not just this one ability.

## Fix

Change `'properties' => []` to `'properties' => new \stdClass()`, matching the pattern already used by other no-parameter abilities in the codebase (`get-active-design.php`, `list-design-library.php`).

## Verification

- `vendor/bin/mago format`, `lint`, and `analyze` all pass with no issues on the changed file.
- Confirmed the vendored `wordpress/mcp-adapter` (`RegisterAbilityAsMcpTool.php` / `McpTool.php`) passes the ability's `input_schema` through to the `tools/list` response as-is, with no normalization of `properties`, so this is the only place the fix needs to live.
