### PR TITLE
Fix OAuth DCR misclassifying multi-grant clients as device-only

### DIFF
--- a/includes/oauth/endpoints/register.php
+++ b/includes/oauth/endpoints/register.php
@@ -117,16 +117,19 @@ function handle(WP_REST_Request $req): WP_REST_Response|WP_Error
 
     // @mago-expect analysis:mixed-assignment
     $requested_grants = $body['grant_types'] ?? null;
+    // @mago-expect analysis:mixed-assignment
+    $redirect_uris = $body['redirect_uris'] ?? null;
+    // A client that supplies redirect_uris needs the Authorization Code flow even if it also lists
+    // device_code among its supported grants, so only the redirect-less case is device-only.
     $device_client =
         is_array($requested_grants)
-        && in_array(\Novamira\OAuth\DEVICE_CODE_GRANT_TYPE, $requested_grants, strict: true);
+        && in_array(\Novamira\OAuth\DEVICE_CODE_GRANT_TYPE, $requested_grants, strict: true)
+        && (!is_array($redirect_uris) || $redirect_uris === []);
 
     if ($device_client) {
         return register_device_client($client_name, $client_ip);
     }
 
-    // @mago-expect analysis:mixed-assignment
-    $redirect_uris = $body['redirect_uris'] ?? null;
     if (!is_array($redirect_uris) || $redirect_uris === []) {
         return new WP_Error('invalid_request', 'redirect_uris must be a non-empty array', ['status' => 400]);
     }


### PR DESCRIPTION
## Summary

Fixes #85. Dynamic Client Registration classified any request listing `device_code` in `grant_types` as device-authorization-only, discarding any `redirect_uris` the client supplied. VS Code's registration request includes both `device_code` and `redirect_uris` (it needs Authorization Code + PKCE via a loopback redirect), so it was misrouted into the device-only branch, ended up with `redirect_uris: []`, and Novamira then rejected its authorization attempts with "This application is registered for device authorization."

## Fix

A client is now classified as device-only only when it requests `device_code` **and** supplies no `redirect_uris`. A client that supplies `redirect_uris` gets the standard `authorization_code` + `refresh_token` registration with those URIs preserved, regardless of what else is in its requested grant types.

This matches the fix proposed in the issue, which includes a full reproduction (VS Code registration payload, failing authorization response, and confirmation that a fresh DCR after the fix succeeds).

## Verification

- `vendor/bin/mago format`, `lint`, and `analyze` are clean on the changed file.
- Full `tests/oauth/` PHPUnit suite (223 tests, 626 assertions) passes unchanged.
