### PR TITLE
Isolate sandbox file crashes instead of aborting the whole request

### DIFF
--- a/includes/sandbox-loader.php
+++ b/includes/sandbox-loader.php
@@ -15,7 +15,24 @@ if (!defined('ABSPATH')) {
 }
 
 /**
+ * Writes the .crashed marker, activating safe mode for sandbox files on the next request.
+ *
+ * @param string               $crashed_file  Path to the .crashed marker file.
+ * @param string               $sandbox_file  The sandbox file responsible for the crash.
+ * @param array<string, mixed> $error         Error details (type, message, file, line).
+ */
+function novamira_sandbox_write_crash_marker(string $crashed_file, string $sandbox_file, array $error): void
+{
+    $error['sandbox_file'] = $sandbox_file;
+    file_put_contents($crashed_file, (string) wp_json_encode($error), LOCK_EX);
+}
+
+/**
  * Shutdown handler that creates a .crashed marker when PHP terminates while a sandbox file is loading.
+ *
+ * Only reachable for a fatal that require_once itself cannot survive (out of memory, a parse error,
+ * a timeout). An uncaught Throwable never reaches here, since the surrounding try/catch in the load
+ * loop below handles it without terminating the request.
  *
  * @param string      $crashed_file        Path to the .crashed marker file.
  * @param string|null $current_sandbox_file The sandbox file currently being loaded, or null if loading is complete.
@@ -36,8 +53,7 @@ function novamira_sandbox_crash_handler(string $crashed_file, ?string $current_s
         ];
     }
 
-    $error['sandbox_file'] = $current_sandbox_file;
-    file_put_contents($crashed_file, (string) wp_json_encode($error), LOCK_EX);
+    novamira_sandbox_write_crash_marker($crashed_file, $current_sandbox_file, $error);
 }
 
 (static function () {
@@ -116,7 +132,19 @@ function novamira_sandbox_crash_handler(string $crashed_file, ?string $current_s
 
     foreach ($files as $file) {
         $current_sandbox_file = $file;
-        require_once $file;
+        try {
+            require_once $file;
+        } catch (\Throwable $e) {
+            // Isolate this file's failure instead of letting it take down the whole request: log it,
+            // arm safe mode for the next request, and keep loading the remaining sandbox files and the
+            // rest of the WordPress bootstrap.
+            novamira_sandbox_write_crash_marker($crashed_file, $file, [
+                'type' => E_ERROR,
+                'message' => $e->getMessage(),
+                'file' => $e->getFile(),
+                'line' => $e->getLine(),
+            ]);
+        }
     }
     $current_sandbox_file = null;
 })();

--- a/tests/integration/SandboxLoaderTest.php
+++ b/tests/integration/SandboxLoaderTest.php
@@ -61,6 +61,23 @@ final class SandboxLoaderTest extends TestCase
         self::assertSame('runner-complete', $secondOutput);
     }
 
+    public function testThrowableFromOneFileDoesNotBlockOtherSandboxFilesOrTheRequest(): void
+    {
+        file_put_contents($this->sandboxDirectory . '/a-crash.php', "<?php throw new \\Error('boom');");
+        file_put_contents(
+            $this->sandboxDirectory . '/b-survivor.php',
+            "<?php file_put_contents(__DIR__ . '/survivor-loaded', '1');",
+        );
+
+        [$output, $exitCode] = $this->runLoader('request');
+
+        self::assertSame(0, $exitCode);
+        self::assertSame('runner-complete', $output);
+        self::assertFileExists($this->sandboxDirectory . '/survivor-loaded');
+        self::assertFileExists($this->sandboxDirectory . '/.crashed');
+        self::assertStringContainsString('boom', (string) file_get_contents($this->sandboxDirectory . '/.crashed'));
+    }
+
     /** @return array{string, int} */
     private function runLoader(string $mode): array
     {


### PR DESCRIPTION
## Summary

Fixes #44. `includes/sandbox-loader.php`'s `require_once` loop had no try/catch, so an uncaught `Throwable` from one sandbox file terminated the whole PHP process for that request. That skipped every remaining sandbox file and cut the rest of WordPress's bootstrap short, which is how a third-party plugin API call failing in one sandbox tool could surface later in the same request as an apparently unrelated fatal elsewhere in WordPress core.

## Fix

Each sandbox file's `require_once` now runs inside `try { ... } catch (\Throwable $e) { ... }`:

- On a caught error, the `.crashed` marker is written immediately with the exception's message/file/line, which arms safe mode for the *next* request exactly as it did before.
- The *current* request now keeps loading the remaining sandbox files and continues through the rest of WordPress's bootstrap instead of dying.
- Failures `require_once` itself cannot survive (out of memory, a parse error, a timeout) are not catchable by any PHP code and still fall through to the pre-existing shutdown-based detection, unchanged.

Extracted the marker-writing logic shared by both paths into `novamira_sandbox_write_crash_marker()` to avoid duplicating the `.crashed` file format.

## Tests

Added `testThrowableFromOneFileDoesNotBlockOtherSandboxFilesOrTheRequest` to `tests/integration/SandboxLoaderTest.php`: one sandbox file throws, a second sandbox file writes a marker file, and the test confirms the second file still runs, the request still completes, and `.crashed` is written with the error message.

## Verification

- `vendor/bin/mago format`, `lint`, and `analyze` are clean on `includes/sandbox-loader.php`.
- `vendor/bin/phpunit tests/integration/SandboxLoaderTest.php` passes (3 tests, 17 assertions).
