### PR TITLE
Stop stray sandbox file output from leaking into every response

### DIFF
--- a/includes/sandbox-loader.php
+++ b/includes/sandbox-loader.php
@@ -132,9 +132,18 @@ function novamira_sandbox_crash_handler(string $crashed_file, ?string $current_s
 
     foreach ($files as $file) {
         $current_sandbox_file = $file;
+        // Sandbox files are meant to register hooks/functions, not print output at require-time: any
+        // top-level echo, stray warning, or leftover debug statement would otherwise land in whatever
+        // response happens to be building on every other request (REST/MCP JSON included) rather than
+        // staying local to this file. Buffer and discard it. A file that deliberately serves its own
+        // response and calls exit() is unaffected, since exit() skips the ob_end_clean() below and
+        // PHP flushes the buffered output normally at shutdown.
+        ob_start();
         try {
             require_once $file;
+            ob_end_clean();
         } catch (\Throwable $e) {
+            ob_end_clean();
             // Isolate this file's failure instead of letting it take down the whole request: log it,
             // arm safe mode for the next request, and keep loading the remaining sandbox files and the
             // rest of the WordPress bootstrap.

--- a/includes/sandbox-loader.php
+++ b/includes/sandbox-loader.php
@@ -15,7 +15,24 @@ if (!defined('ABSPATH')) {
 }
 
 /**
+ * Writes the .crashed marker, activating safe mode for sandbox files on the next request.
+ *
+ * @param string               $crashed_file  Path to the .crashed marker file.
+ * @param string               $sandbox_file  The sandbox file responsible for the crash.
+ * @param array<string, mixed> $error         Error details (type, message, file, line).
+ */
+function novamira_sandbox_write_crash_marker(string $crashed_file, string $sandbox_file, array $error): void
+{
+    $error['sandbox_file'] = $sandbox_file;
+    file_put_contents($crashed_file, (string) wp_json_encode($error), LOCK_EX);
+}
+
+/**
  * Shutdown handler that creates a .crashed marker when PHP terminates while a sandbox file is loading.
+ *
+ * Only reachable for a fatal that require_once itself cannot survive (out of memory, a parse error,
+ * a timeout). An uncaught Throwable never reaches here, since the surrounding try/catch in the load
+ * loop below handles it without terminating the request.
  *
  * @param string      $crashed_file        Path to the .crashed marker file.
  * @param string|null $current_sandbox_file The sandbox file currently being loaded, or null if loading is complete.
@@ -36,8 +53,7 @@ function novamira_sandbox_crash_handler(string $crashed_file, ?string $current_s
         ];
     }
 
-    $error['sandbox_file'] = $current_sandbox_file;
-    file_put_contents($crashed_file, (string) wp_json_encode($error), LOCK_EX);
+    novamira_sandbox_write_crash_marker($crashed_file, $current_sandbox_file, $error);
 }
 
 (static function () {
@@ -116,7 +132,19 @@ function novamira_sandbox_crash_handler(string $crashed_file, ?string $current_s
 
     foreach ($files as $file) {
         $current_sandbox_file = $file;
-        require_once $file;
+        try {
+            require_once $file;
+        } catch (\Throwable $e) {
+            // Isolate this file's failure instead of letting it take down the whole request: log it,
+            // arm safe mode for the next request, and keep loading the remaining sandbox files and the
+            // rest of the WordPress bootstrap.
+            novamira_sandbox_write_crash_marker($crashed_file, $file, [
+                'type' => E_ERROR,
+                'message' => $e->getMessage(),
+                'file' => $e->getFile(),
+                'line' => $e->getLine(),
+            ]);
+        }
     }
     $current_sandbox_file = null;
 })();

--- a/tests/integration/SandboxLoaderTest.php
+++ b/tests/integration/SandboxLoaderTest.php
@@ -61,6 +61,23 @@ final class SandboxLoaderTest extends TestCase
         self::assertSame('runner-complete', $secondOutput);
     }
 
+    public function testThrowableFromOneFileDoesNotBlockOtherSandboxFilesOrTheRequest(): void
+    {
+        file_put_contents($this->sandboxDirectory . '/a-crash.php', "<?php throw new \\Error('boom');");
+        file_put_contents(
+            $this->sandboxDirectory . '/b-survivor.php',
+            "<?php file_put_contents(__DIR__ . '/survivor-loaded', '1');",
+        );
+
+        [$output, $exitCode] = $this->runLoader('request');
+
+        self::assertSame(0, $exitCode);
+        self::assertSame('runner-complete', $output);
+        self::assertFileExists($this->sandboxDirectory . '/survivor-loaded');
+        self::assertFileExists($this->sandboxDirectory . '/.crashed');
+        self::assertStringContainsString('boom', (string) file_get_contents($this->sandboxDirectory . '/.crashed'));
+    }
+
     /** @return array{string, int} */
     private function runLoader(string $mode): array
     {

--- a/tests/integration/SandboxLoaderTest.php
+++ b/tests/integration/SandboxLoaderTest.php
@@ -61,6 +61,19 @@ final class SandboxLoaderTest extends TestCase
         self::assertSame('runner-complete', $secondOutput);
     }
 
+    public function testStrayOutputFromASandboxFileDoesNotLeakIntoTheResponse(): void
+    {
+        file_put_contents(
+            $this->sandboxDirectory . '/extension.php',
+            "<?php echo 'File OK: 42 chars';",
+        );
+
+        [$output, $exitCode] = $this->runLoader('request');
+
+        self::assertSame(0, $exitCode);
+        self::assertSame('runner-complete', $output);
+    }
+
     public function testThrowableFromOneFileDoesNotBlockOtherSandboxFilesOrTheRequest(): void
     {
         file_put_contents($this->sandboxDirectory . '/a-crash.php', "<?php throw new \\Error('boom');");


### PR DESCRIPTION
## Summary

Fixes #67. Sandbox files are `require_once`'d on every request, including REST/MCP requests that must return clean JSON. Nothing captured or contained a sandbox file's output at require-time, so any top-level `echo` (a leftover debug statement, a stray warning) printed directly into whatever response happened to be building for that request, front-end pages and API responses alike. That is the "File OK: N chars" text showing up ahead of OAuth discovery documents and MCP responses, breaking JSON parsing for any client.

## Fix

Each sandbox file's `require_once` now runs inside output buffering (`ob_start()` / `ob_end_clean()`), and the buffer is discarded once the file finishes loading, whether it completed normally or its error was caught by the crash guard from #44/#88. A sandbox file that deliberately serves its own response and calls `exit()` is unaffected: `exit()` skips the discard, so PHP flushes the buffered output normally at shutdown, unchanged from current behavior.

Depends on #88, which adds the try/catch this change wraps in output buffering. Based this branch on top of it to keep the diff here scoped to the output-buffering change only.

## Tests

Added `testStrayOutputFromASandboxFileDoesNotLeakIntoTheResponse`, confirming a sandbox file's stray `echo` no longer appears in the response. The existing `testExitDuringLoadingEnablesSafeModeForTheNextRequest` continues to pass unchanged, confirming a file that intentionally `exit()`s with output still works.

## Verification

- `vendor/bin/mago format`, `lint`, and `analyze` are clean on `includes/sandbox-loader.php`.
- `vendor/bin/phpunit tests/integration/SandboxLoaderTest.php` passes (4 tests, 20 assertions).
