### PR TITLE
Explain why OAuth storage is missing instead of pointing at reactivation

### DIFF
--- a/includes/troubleshoot/checks.php
+++ b/includes/troubleshoot/checks.php
@@ -288,6 +288,33 @@ function check_permalinks(): array
     );
 }
 
+/**
+ * The OAuth installer runs on every request (via the `boot()` guard chain in
+ * includes/oauth/bootstrap.php), not only on activation, so "deactivate and reactivate" does
+ * nothing that the next page load would not already have done. When the tables are missing, name
+ * the guard that is actually blocking `boot()` from ever reaching the installer, instead of
+ * pointing at reactivation as if the installer itself were the failing step.
+ *
+ * @return string|null A specific reason the installer never runs, or null when both guards pass
+ *                      and the missing tables point to the installer itself.
+ */
+function schema_blocked_reason(): ?string
+{
+    if (!\novamira_is_enabled()) {
+        return __(
+            'AI Abilities are turned off (or locked to a different domain than this site), so the OAuth installer never runs. See the "AI Abilities" check above.',
+            domain: 'novamira',
+        );
+    }
+    if (!\novamira_oauth_transport_allowed()) {
+        return __(
+            'This site is not served over HTTPS, so OAuth is disabled here. See the "Secure transport" check above.',
+            domain: 'novamira',
+        );
+    }
+    return null;
+}
+
 /** @return array{id: string, status: string, label: string, message: string, remedy: string, action: string, copy: string} */
 function check_schema(): array
 {
@@ -301,12 +328,23 @@ function check_schema(): array
     if (is_string($found) && $found === $table) {
         return ok('schema', $label, __('The OAuth tables are installed.', domain: 'novamira'));
     }
+
+    $blocked_reason = schema_blocked_reason();
+    if ($blocked_reason !== null) {
+        return fail(
+            'schema',
+            $label,
+            $blocked_reason,
+            __('Resolve the blocking check above, then run these checks again.', domain: 'novamira'),
+        );
+    }
+
     return fail(
         'schema',
         $label,
         __('The OAuth tables are missing, so no OAuth client can register or authenticate.', domain: 'novamira'),
         __(
-            'Deactivate and reactivate Novamira to re-run the installer, then run these checks again.',
+            'AI Abilities are on and this site is served over HTTPS, so the installer should have run. Check the PHP error log for a database error, then run these checks again; deactivating and reactivating Novamira re-triggers the same installer but will not help if the underlying database error persists.',
             domain: 'novamira',
         ),
     );


### PR DESCRIPTION
## Summary

Related to #81 and #65. Both report the Troubleshoot page's "OAuth storage" check failing with "The OAuth tables are missing" and a remedy of "deactivate and reactivate Novamira to re-run the installer," which does not help: the OAuth installer (`Schema\maybe_install()`) is not tied to plugin activation. It runs on every request through the `boot()` guard chain in `includes/oauth/bootstrap.php`, gated behind `novamira_is_enabled()` and `novamira_oauth_transport_allowed()`. If either guard returns false, `boot()` returns before the installer is ever reached, and the misleading remedy sends users into a reactivate loop that changes nothing.

## Fix

`check_schema()` now re-evaluates the same two guards `boot()` checks when the tables are missing:

- If AI Abilities are off (or domain-locked to a different host), it says so directly.
- If the site isn't served over HTTPS, it says so directly.
- Only when both guards pass and the tables are still missing does it fall back to a genuine installer-failure message, now pointing at the PHP error log instead of reactivation.

This does not, and cannot from this repository alone, resolve *why* either guard might be silently rejecting a specific site (see the discussion on #81 for what I could and couldn't confirm there); it replaces a misleading remedy with an accurate, actionable one and makes the actual blocker visible instead of a silent, undiagnosable failure.

## Verification

- `vendor/bin/mago format`, `lint`, and `analyze` are clean on the changed file.
- `php -l` passes. No existing test coverage exists for `includes/troubleshoot/checks.php` (it depends on a live `$wpdb`/WordPress runtime), so I did not add new test infrastructure for a small, low-risk message change.
